### PR TITLE
optimised ChromeDriver and FirefoxDriver

### DIFF
--- a/src/main/java/io/github/bonigarcia/wdm/ChromeDriverManager.java
+++ b/src/main/java/io/github/bonigarcia/wdm/ChromeDriverManager.java
@@ -16,11 +16,9 @@
  */
 package io.github.bonigarcia.wdm;
 
-import static io.github.bonigarcia.wdm.DriverManagerType.CHROME;
-import static java.util.Arrays.asList;
-
 import java.io.IOException;
 import java.net.URL;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -31,37 +29,41 @@ import java.util.List;
  */
 public class ChromeDriverManager extends WebDriverManager {
 
+    private static final String CHROME_DRIVER_VERSION_KEY = "wdm.chromeDriverVersion";
+    private static final String CHROME_DRIVER_URL_KEY = "wdm.chromeDriverUrl";
+    private static final String CHROME_DRIVER_MIRROR_URL_KEY = "wdm.chromeDriverMirrorUrl";
+    private static final String CHROME_DRIVER_EXPORT_PARAM_KEY = "wdm.chromeDriverExport";
+    private static final List<String> CHROME_DRIVER_NAME = Collections.singletonList("chromedriver");
+
     public static synchronized WebDriverManager getInstance() {
         return chromedriver();
     }
 
     public ChromeDriverManager() {
-        driverManagerType = CHROME;
-        exportParameterKey = "wdm.chromeDriverExport";
-        driverVersionKey = "wdm.chromeDriverVersion";
-        driverUrlKey = "wdm.chromeDriverUrl";
-        driverMirrorUrlKey = "wdm.chromeDriverMirrorUrl";
-        driverName = asList("chromedriver");
+        driverManagerType = DriverManagerType.CHROME;
+        exportParameterKey = CHROME_DRIVER_EXPORT_PARAM_KEY;
+        driverVersionKey = CHROME_DRIVER_VERSION_KEY;
+        driverUrlKey = CHROME_DRIVER_URL_KEY;
+        driverMirrorUrlKey = CHROME_DRIVER_MIRROR_URL_KEY;
+        driverName = CHROME_DRIVER_NAME;
     }
 
     @Override
     protected List<URL> getDrivers() throws IOException {
         URL driverUrl = config().getDriverUrl(driverUrlKey);
-        List<URL> urls;
         if (isUsingTaobaoMirror()) {
-            urls = getDriversFromMirror(driverUrl);
+            return getDriversFromMirror(driverUrl);
         } else {
-            urls = getDriversFromXml(driverUrl);
+            return getDriversFromXml(driverUrl);
         }
-        return urls;
     }
 
     @Override
     protected String getCurrentVersion(URL url, String driverName) {
         if (isUsingTaobaoMirror()) {
-            int i = url.getFile().lastIndexOf(SLASH);
-            int j = url.getFile().substring(0, i).lastIndexOf(SLASH) + 1;
-            return url.getFile().substring(j, i);
+            int lastSlashIndex = url.getFile().lastIndexOf('/');
+            int secondLastSlashIndex = url.getFile().substring(0, lastSlashIndex).lastIndexOf('/') + 1;
+            return url.getFile().substring(secondLastSlashIndex, lastSlashIndex);
         } else {
             return super.getCurrentVersion(url, driverName);
         }

--- a/src/main/java/io/github/bonigarcia/wdm/FirefoxDriverManager.java
+++ b/src/main/java/io/github/bonigarcia/wdm/FirefoxDriverManager.java
@@ -17,7 +17,6 @@
 package io.github.bonigarcia.wdm;
 
 import static io.github.bonigarcia.wdm.DriverManagerType.FIREFOX;
-import static io.github.bonigarcia.wdm.OperatingSystem.MAC;
 import static java.util.Arrays.asList;
 
 import java.io.IOException;
@@ -54,10 +53,7 @@ public class FirefoxDriverManager extends WebDriverManager {
     protected String getCurrentVersion(URL url, String driverName) {
         String currentVersion = url.getFile().substring(
                 url.getFile().indexOf('-') + 1, url.getFile().lastIndexOf('-'));
-        if (currentVersion.startsWith("v")) {
-            currentVersion = currentVersion.substring(1);
-        }
-        return currentVersion;
+        return currentVersion.startsWith("v") ? currentVersion.substring(1) : currentVersion;
     }
 
     @Override
@@ -82,6 +78,6 @@ public class FirefoxDriverManager extends WebDriverManager {
 
     @Override
     protected boolean shouldCheckArchitecture() {
-        return !config().getOs().contains(MAC.name());
+        return !OperatingSystem.MAC.equals(config().getOs());
     }
 }


### PR DESCRIPTION
**### ChromeDriver changes :**
- Removed the static import of _asList()_ and _CHROME_ as they are only used once.
- Changed the visibility of the constants to private and renamed them with a more descriptive name.
- Removed unnecessary initialization of urls with null in getDrivers() method.
- Simplified the logic in _getDrivers()_ method by removing the urls variable and returning the value directly.
- Renamed the variables i and j in _getCurrentVersion()_ method to lastSlashIndex and secondLastSlashIndex, respectively, for clarity.
- Removed unnecessary else block in getCurrentVersion() method.

**### FirefoxDriver changes :**
- Removing the import of _OperatingSystem.MAC_ and using it directly in the _shouldCheckArchitecture()_ method instead of comparing strings.
- Combining the if statement and the conditional operator in the _getCurrentVersion()_ method to make it more concise.
- Removing the redundant toLowerCase() method call in the _preDownload()_ method.
